### PR TITLE
perf: `containers.List` support return id only

### DIFF
--- a/cmd/ctr/commands/containers/containers.go
+++ b/cmd/ctr/commands/containers/containers.go
@@ -102,16 +102,17 @@ var listCommand = cli.Command{
 			Usage: "Print only the container id",
 		},
 	},
-	Action: func(context *cli.Context) error {
+	Action: func(cliContext *cli.Context) error {
 		var (
-			filters = context.Args()
-			quiet   = context.Bool("quiet")
+			filters = cliContext.Args()
+			quiet   = cliContext.Bool("quiet")
 		)
-		client, ctx, cancel, err := commands.NewClient(context)
+		client, ctx, cancel, err := commands.NewClient(cliContext)
 		if err != nil {
 			return err
 		}
 		defer cancel()
+		ctx = context.WithValue(ctx, "list_container_quiet", quiet)
 		containers, err := client.Containers(ctx, filters...)
 		if err != nil {
 			return err

--- a/metadata/containers.go
+++ b/metadata/containers.go
@@ -73,6 +73,11 @@ func (s *containerStore) Get(ctx context.Context, id string) (containers.Contain
 	return container, nil
 }
 
+func (s *containerStore) ListQuietly(ctx context.Context) ([]containers.Container, error) {
+	ctx = context.WithValue(ctx, "list_container_quiet", true)
+	return s.List(ctx)
+}
+
 func (s *containerStore) List(ctx context.Context, fs ...string) ([]containers.Container, error) {
 	namespace, err := namespaces.NamespaceRequired(ctx)
 	if err != nil {


### PR DESCRIPTION
Aim to reduce memory usage